### PR TITLE
Fixed a bug where the weakest equivalence relation wasn't being updated

### DIFF
--- a/solutions/java/src/main/java/com/epi/EquivClasses.java
+++ b/solutions/java/src/main/java/com/epi/EquivClasses.java
@@ -37,9 +37,11 @@ public class EquivClasses {
     }
 
     // Generates the weakest equivalence relation.
+    int i = 0;
     for (int f : F) {
       while (f != F.get(f)) {
         f = F.get(f);
+        F.set(i, f);
       }
     }
     return F;


### PR DESCRIPTION
With the old code, if you reverse the order of the lists, you get the wrong answer.

e.g.:
List A = Arrays.asList(6, 3, 5, 1);
List B = Arrays.asList(5, 0, 1, 2);

Outputs:
[0, 1, 1, 0, 4, 1, 5]

Instead of:
[0, 1, 1, 0, 4, 1, 1]

This commit fixes that. The equivalent C++ doesn't have the same problem.
