### PR TITLE
Move interrupt() out of try_catch for better readability.

### DIFF
--- a/solutions/java/concurrency/AsyncThread.java
+++ b/solutions/java/concurrency/AsyncThread.java
@@ -48,10 +48,10 @@ public class AsyncThread {
         innerThread.start();
         try {
           Thread.sleep(TIMEOUT);
-          innerThread.interrupt();
         } catch(InterruptedException e) {
           e.printStackTrace();
         }
+        innerThread.interrupt();
       }
     };
     new Thread(task).start();


### PR DESCRIPTION
Since interrupt() wont throw any checked exception; moving out of try/catch. And now it will be more clear that InterruptedException got at innerThread due to this interrupt() call.