### PR TITLE
Update merge_sorted_arrays.h

### DIFF
--- a/solutions/cpp/merge_sorted_arrays.h
+++ b/solutions/cpp/merge_sorted_arrays.h
@@ -27,7 +27,7 @@ struct IteratorCurrentAndEnd {
 
 vector<int> MergeSortedArrays(const vector<vector<int>>& sorted_arrays) {
   priority_queue<IteratorCurrentAndEnd, vector<IteratorCurrentAndEnd>,
-                 greater<>>
+                 greater<IteratorCurrentAndEnd> >
       min_heap;
 
   for (const vector<int>& sorted_array : sorted_arrays) {


### PR DESCRIPTION
Comparator 'greater' should also include the type. Compilation fails with the following error. error: wrong number of template arguments (0, should be 1) priority_queue<IteratorCurrAndEnd, vector greater<> > min_heap;
Proposed change is to simply include the type.
Using the following compiler version: g++ --version; Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1 Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn) Target: x86_64-apple-darwin13.4.0 Thread model: posix