### PR TITLE
Fix link to "read this first" page

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,7 @@ We made numerous calls to Amazon and Createspace (the publisher), but were never
 	<h4>Links</h4>
 	<ul class="blogroll list-unstyled">
 	
-		<li><i class="fa fa-spinner fa-spin fa-lg fa-fw"></i><a href="2017/11/27/2017-11-27-buying-epi" title="Buying EPI from Amazon" target="_blank"]);">READ THIS FIRST!!!</a></li>
+		<li><i class="fa fa-spinner fa-spin fa-lg fa-fw"></i><a href="/2017/11/27/2017-11-27-buying-epi" title="Buying EPI from Amazon" target="_blank"]);">READ THIS FIRST!!!</a></li>
 	
 		<li><i class="fa fa-code"></i><a href="http://epijudge.com" title="Solution code" target="_blank"]);">Solution code</a></li>
 	


### PR DESCRIPTION
This link would not work if you were anywhere else but the home page. Found this while browsing the site. Thanks!